### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -28,7 +28,7 @@ jobs:
       - id: matrix
         uses: php/php-windows-builder/extension-matrix@v1
         with:
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
 
   build:
     name: Build ${{ matrix.php-version }} ${{ matrix.ts }} ${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP

--- a/.release-config
+++ b/.release-config
@@ -7,6 +7,8 @@ version_macro: PHP_FAST_UUID_VERSION  # from php_fast_uuid.h
 version_file: php_fast_uuid.h
 repo: iliaal/fast_uuid                # composer.json name; no git remote configured yet
 build_matrix:
+  - PHP-8.1
+  - PHP-8.2
   - PHP-8.3
   - PHP-8.4
   - PHP-8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PHP 8.1 support (lowered the minimum from 8.3).
 - ARM64 builds now use a NEON table-lookup hex formatter for UUID string output,
   matching the existing SSSE3 fast path on x86-64.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full API reference with runnable examples: [docs/index.html](docs/index.html). B
 
 ## Requirements
 
-- PHP 8.3 through 8.6, NTS or ZTS. PHP 8.3 builds via two small `#if PHP_VERSION_ID < 80400` polyfills.
+- PHP 8.1 through 8.6, NTS or ZTS. PHP 8.1/8.2/8.3 build via small `#if PHP_VERSION_ID` polyfills.
 - x86-64 and ARM64 get the SIMD formatter automatically; other architectures fall back to the scalar path. No build flags needed either way.
 - No external libraries. v1 and v6 use an internal RFC-compliant generator with a random node (multicast bit set, per RFC 9562 §5.1). v3 and v5 use PHP's bundled MD5/SHA1.
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.1"
     },
     "php-ext": {
         "extension-name": "fast_uuid",

--- a/fast_uuid.c
+++ b/fast_uuid.c
@@ -826,7 +826,12 @@ PHP_METHOD(FastUuid_Uuid, uuid7) {
         if (fu_gen_v7(b) == FAILURE) RETURN_THROWS();
     } else {
         zend_argument_type_error(1, "must be of type int|DateTimeInterface|null, %s given",
+#if PHP_VERSION_ID >= 80300
                                  zend_zval_value_name(when));
+#else
+                                 /* zend_zval_value_name is 8.3+; 8.1/8.2 use the type-name form */
+                                 zend_zval_type_name(when));
+#endif
         RETURN_THROWS();
     }
     fu_return_uuid(return_value, b);


### PR DESCRIPTION
Lowers the minimum supported PHP from 8.3 to 8.1.

## Blocker

`FastUuid\Uuid::uuid7()`'s invalid-argument error path called `zend_zval_value_name()` unconditionally. That function is 8.3+; on 8.1/8.2 it compiled with an implicit declaration (`-Wimplicit-function-declaration`) and the symbol failed to resolve at load/call time, so hitting the bad-argument branch crashed with a symbol lookup error. Guarded it: 8.3+ keeps `zend_zval_value_name()`, 8.1/8.2 fall back to `zend_zval_type_name()` (same `const char *(const zval *)` signature, available since 8.1). The error message is identical for the string case.

The pre-existing `#if PHP_VERSION_ID >= 80300` random-header guard and the `< 80400` arginfo polyfill already covered the rest of the surface and were left as-is. No `-lt` gate was added to `config.m4` (it never had one).

## Floor / CI

- `composer.json` `">=8.3"` → `">=8.1"`, README version line updated.
- Added `8.1`/`8.2` to the test matrix (`tests.yml`), the Windows `php-version-list`, and `.release-config`'s `build_matrix`.

## Verification

Built and tested on local ASAN PHP 8.1.34 and 8.2.31, plain `--enable-fast-uuid` (no `-Werror`/`-dev`):

- Build: 0 warnings, 0 errors on both. The previous `-Wimplicit-function-declaration` warning is gone and the symbol resolves.
- uuid7 crash path: `FastUuid\Uuid::uuid7("notatime")` now throws cleanly on both — `TypeError: ... must be of type int|DateTimeInterface|null, string given`, no symbol lookup error.
- Full suite each version: 29 passed, 0 failed, 1 skipped (`019_fork_safety` — pcntl not built into the local PHP, environmental).